### PR TITLE
Ganesha grace period & recovery

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,6 +1,11 @@
 # Modified from https://github.com/rootfs/nfs-ganesha-docker by Huamin Chen
 FROM fedora:24
 
+# Build ganesha from source, installing deps and removing them in one line.
+# Why?
+# 1. Root_Id_Squash, only present in >= 2.4.0.3 which is not yet packaged
+# 2. Set NFS_V4_RECOV_ROOT to /export
+
 RUN dnf install -y tar gcc cmake autoconf libtool bison flex make gcc-c++ krb5-devel dbus-devel dbus-x11 rpcbind hostname nfs-utils && dnf clean all \
 	&& curl -L https://github.com/nfs-ganesha/nfs-ganesha/archive/V2.4.0.3.tar.gz | tar zx \
 	&& curl -L https://github.com/nfs-ganesha/ntirpc/archive/v1.4.1.tar.gz | tar zx \
@@ -8,12 +13,13 @@ RUN dnf install -y tar gcc cmake autoconf libtool bison flex make gcc-c++ krb5-d
 	&& mv ntirpc-1.4.1 nfs-ganesha-2.4.0.3/src/libntirpc \
 	&& cd nfs-ganesha-2.4.0.3 \
 	&& cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_CONFIG=vfs_only src/ \
+	&& sed -i 's|@SYSSTATEDIR@/lib/nfs/ganesha|/export|' src/include/config-h.in.cmake \
 	&& make \
 	&& make install \
 	&& cp src/scripts/ganeshactl/org.ganesha.nfsd.conf /etc/dbus-1/system.d/ \
 	&& dnf remove -y tar gcc cmake autoconf libtool bison flex make gcc-c++ krb5-devel dbus-devel && dnf clean all
 
-RUN mkdir /var/run/dbus
+RUN mkdir -p /var/run/dbus
 RUN mkdir -p /export
 
 # expose mountd 20048/tcp and nfsd 2049/tcp and rpcbind 111/tcp 111/udp

--- a/deploy/docker/vfs.conf
+++ b/deploy/docker/vfs.conf
@@ -33,3 +33,8 @@ NFS_Core_Param
 {
 	MNT_Port = 20048;
 }
+
+NFSV4
+{
+	Grace_Period = 90;
+}

--- a/deploy/kube-config/pod.yaml
+++ b/deploy/kube-config/pod.yaml
@@ -22,6 +22,7 @@ spec:
             - DAC_READ_SEARCH
       args:
         - "-provisioner=matthew/nfs"
+        - "-grace-period=0"
       env:
         - name: POD_IP
           valueFrom:

--- a/deploy/kube-config/pod_emptydir.yaml
+++ b/deploy/kube-config/pod_emptydir.yaml
@@ -22,6 +22,7 @@ spec:
             - DAC_READ_SEARCH
       args:
         - "-provisioner=matthew/nfs"
+        - "-grace-period=0"
       env:
         - name: POD_IP
           valueFrom:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -173,3 +173,4 @@ The pod requires authorization to `list` all `StorageClasses`, `PersistentVolume
 * `kubeconfig` - Absolute path to the kubeconfig file. Either this or master needs to be set if the provisioner is being run out of cluster.
 * `run-server` - If the provisioner is responsible for running the NFS server, i.e. starting and stopping NFS Ganesha. Default true.
 * `use-ganesha` - If the provisioner will create volumes using NFS Ganesha (D-Bus method calls) as opposed to using the kernel NFS server ('exportfs'). If run-server is true, this must be true. Default true.
+* `grace-period` - NFS Ganesha grace period to use in seconds, from 0-180. If the server is not expected to survive restarts, i.e. it is running as a pod & its export directory is not persisted, this can be set to 0. Can only be set if both run-server and use-ganesha are true. Default 90.

--- a/main.go
+++ b/main.go
@@ -39,6 +39,7 @@ var (
 	kubeconfig  = flag.String("kubeconfig", "", "Absolute path to the kubeconfig file. Either this or master needs to be set if the provisioner is being run out of cluster.")
 	runServer   = flag.Bool("run-server", true, "If the provisioner is responsible for running the NFS server, i.e. starting and stopping NFS Ganesha. Default true.")
 	useGanesha  = flag.Bool("use-ganesha", true, "If the provisioner will create volumes using NFS Ganesha (D-Bus method calls) as opposed to using the kernel NFS server ('exportfs'). If run-server is true, this must be true. Default true.")
+	gracePeriod = flag.Uint("grace-period", 90, "NFS Ganesha grace period to use in seconds, from 0-180. If the server is not expected to survive restarts, i.e. it is running as a pod & its export directory is not persisted, this can be set to 0. Can only be set if both run-server and use-ganesha are true. Default 90.")
 )
 
 const ganeshaConfig = "/export/vfs.conf"
@@ -56,9 +57,15 @@ func main() {
 		glog.Fatalf("Invalid flags specified: if run-server is true, use-ganesha must also be true.")
 	}
 
+	if *gracePeriod != 90 && (!*runServer || !*useGanesha) {
+		glog.Fatalf("Invalid flags specified: custom grace period can only be set if both run-server and use-ganesha are true.")
+	} else if *gracePeriod > 180 && *runServer && *useGanesha {
+		glog.Fatalf("Invalid flags specified: custom grace period must be in the range 0-180")
+	}
+
 	if *runServer {
 		glog.Infof("Starting NFS server!")
-		err := server.Start(ganeshaConfig)
+		err := server.Start(ganeshaConfig, *gracePeriod)
 		if err != nil {
 			glog.Fatalf("Error starting NFS server: %v", err)
 		}


### PR DESCRIPTION
Fixes https://github.com/kubernetes-incubator/nfs-provisioner/issues/8

Adds -grace-period flag. Configure ganesha to use /export as NFS_v4_RECOV_ROOT instead of /var/... which is gone upon pod restart.