### PR TITLE
Make StorageClass parameters available to Delete()

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -454,29 +454,9 @@ func (ctrl *ProvisionController) provisionClaimOperation(claim *v1.PersistentVol
 		return nil
 	}
 
-	classObj, found, err := ctrl.classes.GetByKey(claimClass)
+	storageClass, err := ctrl.getStorageClass(claimClass)
 	if err != nil {
-		glog.Errorf("Error getting StorageClass %q of claim %q: %v", claimClass, claimToClaimKey(claim), err)
-		return nil
-	}
-	if !found {
-		glog.Errorf("StorageClass %q of claim %q not found", claimClass, claimToClaimKey(claim))
-		// 3. It tries to find a StorageClass instance referenced by annotation
-		//    `claim.Annotations["volume.beta.kubernetes.io/storage-class"]`. If not
-		//    found, it SHOULD report an error (by sending an event to the claim) and it
-		//    SHOULD retry periodically with step i.
-		return nil
-	}
-	storageClass, ok := classObj.(*v1beta1.StorageClass)
-	if !ok {
-		glog.Errorf("Cannot convert object to StorageClass: %+v", classObj)
-		return nil
-	}
-	if storageClass.Provisioner != ctrl.provisionerName {
-		// class.Provisioner has either changed since shouldProvision() or
-		// annDynamicallyProvisioned contains different provisioner than
-		// class.Provisioner.
-		glog.Errorf("Unknown provisioner %q requested in storage class %q of claim %q", storageClass.Provisioner, claimClass, claimToClaimKey(claim))
+		glog.Errorf("claim %v: %v", claimToClaimKey(claim), err)
 		return nil
 	}
 
@@ -528,7 +508,7 @@ func (ctrl *ProvisionController) provisionClaimOperation(claim *v1.PersistentVol
 		ctrl.eventRecorder.Event(claim, v1.EventTypeWarning, "ProvisioningFailed", strerr)
 
 		for i := 0; i < ctrl.createProvisionedPVRetryCount; i++ {
-			if err = ctrl.provisioner.Delete(volume); err == nil {
+			if err = ctrl.provisioner.Delete(volume, storageClass.Parameters); err == nil {
 				// Delete succeeded
 				glog.V(4).Infof("provisionClaimOperation [%s]: cleaning volume %s succeeded", claimToClaimKey(claim), volume.Name)
 				break
@@ -681,7 +661,13 @@ func (ctrl *ProvisionController) deleteVolumeOperation(volume *v1.PersistentVolu
 		return nil
 	}
 
-	if err := ctrl.provisioner.Delete(volume); err != nil {
+	storageClass, err := ctrl.getStorageClass(volume.Annotations[annClass])
+	if err != nil {
+		glog.Error(err)
+		return nil
+	}
+
+	if err := ctrl.provisioner.Delete(volume, storageClass.Parameters); err != nil {
 		if ierr, ok := err.(*IgnoredError); ok {
 			// Delete ignored, do nothing and hope another provisioner will delete it.
 			glog.Infof("deletion of volume %q ignored: %v", volume.Name, ierr)
@@ -728,6 +714,31 @@ func (ctrl *ProvisionController) scheduleOperation(operationName string, operati
 			glog.Errorf("Error scheduling operaion %q: %v", operationName, err)
 		}
 	}
+}
+
+func (ctrl *ProvisionController) getStorageClass(name string) (*v1beta1.StorageClass, error) {
+	classObj, found, err := ctrl.classes.GetByKey(name)
+	if err != nil {
+		return nil, fmt.Errorf("Error getting StorageClass %q: %v", name, err)
+	}
+	if !found {
+		return nil, fmt.Errorf("StorageClass %q not found", name)
+		// 3. It tries to find a StorageClass instance referenced by annotation
+		//    `claim.Annotations["volume.beta.kubernetes.io/storage-class"]`. If not
+		//    found, it SHOULD report an error (by sending an event to the claim) and it
+		//    SHOULD retry periodically with step i.
+	}
+	storageClass, ok := classObj.(*v1beta1.StorageClass)
+	if !ok {
+		return nil, fmt.Errorf("Cannot convert object to StorageClass: %+v", classObj)
+	}
+	if storageClass.Provisioner != ctrl.provisionerName {
+		// class.Provisioner has either changed since shouldProvision() or
+		// annDynamicallyProvisioned contains different provisioner than
+		// class.Provisioner.
+		return nil, fmt.Errorf("Unknown provisioner %q requested in storage class %q", storageClass.Provisioner, name)
+	}
+	return storageClass, nil
 }
 
 func hasAnnotation(obj v1.ObjectMeta, ann string) bool {

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -71,13 +71,23 @@ func TestController(t *testing.T) {
 		{
 			name: "delete volume-1 but not volume-2",
 			objs: []runtime.Object{
-				newVolume("volume-1", v1.VolumeReleased, v1.PersistentVolumeReclaimDelete, map[string]string{annDynamicallyProvisioned: "foo.bar/baz"}),
-				newVolume("volume-2", v1.VolumeReleased, v1.PersistentVolumeReclaimDelete, map[string]string{annDynamicallyProvisioned: "abc.def/ghi"}),
+				newStorageClass("class-1", "foo.bar/baz"),
+				newVolume("volume-1", v1.VolumeReleased, v1.PersistentVolumeReclaimDelete, map[string]string{
+					annClass:                  "class-1",
+					annDynamicallyProvisioned: "foo.bar/baz",
+				}),
+				newVolume("volume-2", v1.VolumeReleased, v1.PersistentVolumeReclaimDelete, map[string]string{
+					annClass:                  "class-1",
+					annDynamicallyProvisioned: "abc.def/ghi",
+				}),
 			},
 			provisionerName: "foo.bar/baz",
 			provisioner:     newTestProvisioner(),
 			expectedVolumes: []v1.PersistentVolume{
-				*newVolume("volume-2", v1.VolumeReleased, v1.PersistentVolumeReclaimDelete, map[string]string{annDynamicallyProvisioned: "abc.def/ghi"}),
+				*newVolume("volume-2", v1.VolumeReleased, v1.PersistentVolumeReclaimDelete, map[string]string{
+					annClass:                  "class-1",
+					annDynamicallyProvisioned: "abc.def/ghi",
+				}),
 			},
 		},
 		{
@@ -557,7 +567,7 @@ func (p *testProvisioner) Provision(options VolumeOptions) (*v1.PersistentVolume
 	return pv, nil
 }
 
-func (p *testProvisioner) Delete(volume *v1.PersistentVolume) error {
+func (p *testProvisioner) Delete(volume *v1.PersistentVolume, parameters map[string]string) error {
 	return nil
 }
 
@@ -574,7 +584,7 @@ func (p *badTestProvisioner) Provision(options VolumeOptions) (*v1.PersistentVol
 	return nil, errors.New("fake error")
 }
 
-func (p *badTestProvisioner) Delete(volume *v1.PersistentVolume) error {
+func (p *badTestProvisioner) Delete(volume *v1.PersistentVolume, parameters map[string]string) error {
 	return errors.New("fake error")
 }
 

--- a/controller/volume.go
+++ b/controller/volume.go
@@ -40,7 +40,7 @@ type Provisioner interface {
 	// class, provisioners may ignore PVs they are not responsible for (e.g. ones
 	// they didn't create). The controller will act accordingly, i.e. it won't
 	// emit a misleading VolumeFailedDelete event.
-	Delete(*v1.PersistentVolume) error
+	Delete(*v1.PersistentVolume, map[string]string) error
 }
 
 type IgnoredError struct {

--- a/volume/delete.go
+++ b/volume/delete.go
@@ -28,7 +28,7 @@ import (
 
 // Delete removes the directory that was created by Provision backing the given
 // PV and removes its export from the NFS server.
-func (p *nfsProvisioner) Delete(volume *v1.PersistentVolume) error {
+func (p *nfsProvisioner) Delete(volume *v1.PersistentVolume, params map[string]string) error {
 	// Ignore the call if this provisioner was not the one to provision the
 	// volume. It doesn't even attempt to delete it, so it's neither a success
 	// (nil error) nor failure (any other error)


### PR DESCRIPTION
Custom provisioners may require the StorageParams parameters when deleting a volume (e.g. to access a storage system's management API for deleting).