### PR TITLE
Patch Ganesha to use device number as fsid for overlayfs

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -5,21 +5,24 @@ FROM fedora:24
 # Why?
 # 1. Root_Id_Squash, only present in >= 2.4.0.3 which is not yet packaged
 # 2. Set NFS_V4_RECOV_ROOT to /export
+# 3. Use device major/minor as fsid major/minor to work on OverlayFS
 
-RUN dnf install -y tar gcc cmake autoconf libtool bison flex make gcc-c++ krb5-devel dbus-devel jemalloc libnfsidmap && dnf clean all \
+COPY nfs-ganesha.patch /nfs-ganesha.patch
+
+RUN dnf install -y tar gcc cmake autoconf libtool bison flex make gcc-c++ krb5-devel dbus-devel jemalloc-devel libnfsidmap-devel patch && dnf clean all \
 	&& curl -L https://github.com/nfs-ganesha/nfs-ganesha/archive/V2.4.0.3.tar.gz | tar zx \
 	&& curl -L https://github.com/nfs-ganesha/ntirpc/archive/v1.4.1.tar.gz | tar zx \
 	&& rm -r nfs-ganesha-2.4.0.3/src/libntirpc \
 	&& mv ntirpc-1.4.1 nfs-ganesha-2.4.0.3/src/libntirpc \
 	&& cd nfs-ganesha-2.4.0.3 \
 	&& cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_CONFIG=vfs_only src/ \
-	&& sed -i 's|@SYSSTATEDIR@/lib/nfs/ganesha|/export|' src/include/config-h.in.cmake \
+	&& patch -p1 < /nfs-ganesha.patch \
 	&& make \
 	&& make install \
 	&& cp src/scripts/ganeshactl/org.ganesha.nfsd.conf /etc/dbus-1/system.d/ \
-	&& dnf remove -y tar gcc cmake autoconf libtool bison flex make gcc-c++ krb5-devel dbus-devel jemalloc libnfsidmap && dnf clean all
+	&& dnf remove -y tar gcc cmake autoconf libtool bison flex make gcc-c++ krb5-devel dbus-devel jemalloc-devel libnfsidmap-devel patch && dnf clean all
 
-RUN dnf install -y dbus-x11 rpcbind hostname nfs-utils xfsprogs
+RUN dnf install -y dbus-x11 rpcbind hostname nfs-utils xfsprogs jemalloc libnfsidmap
 
 RUN mkdir -p /var/run/dbus
 RUN mkdir -p /export

--- a/deploy/docker/nfs-ganesha.patch
+++ b/deploy/docker/nfs-ganesha.patch
@@ -1,0 +1,27 @@
+diff --git a/src/FSAL/commonlib.c b/src/FSAL/commonlib.c
+index ff860c0..f6db0e7 100644
+--- a/src/FSAL/commonlib.c
++++ b/src/FSAL/commonlib.c
+@@ -1070,6 +1070,9 @@ static void posix_create_file_system(struct mntent *mnt)
+ 
+ 	fs->pathlen = strlen(mnt->mnt_dir);
+ 
++	fs->fsid.minor = fs->dev.minor;
++	fs->fsid.major = fs->dev.major;
++
+ 	node = avltree_insert(&fs->avl_fsid, &avl_fsid);
+ 
+ 	if (node != NULL) {
+diff --git a/src/include/config-h.in.cmake b/src/include/config-h.in.cmake
+index 9d65e83..b5f4bbe 100644
+--- a/src/include/config-h.in.cmake
++++ b/src/include/config-h.in.cmake
+@@ -60,7 +60,7 @@
+ 
+ #define GANESHA_CONFIG_PATH "@SYSCONFDIR@/ganesha/ganesha.conf"
+ #define GANESHA_PIDFILE_PATH "@SYSSTATEDIR@/run/ganesha.pid"
+-#define NFS_V4_RECOV_ROOT "@SYSSTATEDIR@/lib/nfs/ganesha"
++#define NFS_V4_RECOV_ROOT "/export"
+ /**
+  * @brief Default value for krb5_param.ccache_dir
+  */


### PR DESCRIPTION
fixes https://github.com/kubernetes-incubator/nfs-provisioner/issues/60

Still need to test this doesn't break anything. appears to work fine with overlayfs & devicemapper storage drivers. Opened https://github.com/nfs-ganesha/nfs-ganesha/issues/140 to ask for help.