### PR TITLE
Adds configurable number of retries on failed Provisioner operations

### DIFF
--- a/demo/hostpath-provisioner/hostpath-provisioner.go
+++ b/demo/hostpath-provisioner/hostpath-provisioner.go
@@ -17,6 +17,10 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+const (
+	failedRetryThreshold = 5
+)
+
 type hostPathProvisioner struct {
 	// The directory to create PV-backing directories in
 	pvDir string
@@ -114,6 +118,6 @@ func main() {
 
 	// Start the provision controller which will dynamically provision hostPath
 	// PVs
-	pc := controller.NewProvisionController(clientset, 15*time.Second, "example.com/hostpath", hostPathProvisioner, serverVersion.GitVersion, false)
+	pc := controller.NewProvisionController(clientset, 15*time.Second, "example.com/hostpath", hostPathProvisioner, serverVersion.GitVersion, false, failedRetryThreshold)
 	pc.Run(wait.NeverStop)
 }

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -106,7 +106,8 @@ $ docker run --cap-add DAC_READ_SEARCH \
 -v $HOME/.kube:/.kube:Z \
 quay.io/kubernetes_incubator/nfs-provisioner:v1.0.2 \
 -provisioner=example.com/nfs \
--kubeconfig=/.kube/config
+-kubeconfig=/.kube/config \
+-failed-retry-threshold=10
 ```
 or
 ```
@@ -130,7 +131,8 @@ $ docker run --privileged \
 quay.io/kubernetes_incubator/nfs-provisioner:v1.0.2 \
 -provisioner=example.com/nfs \
 -kubeconfig=/.kube/config \
--enable-xfs-quota=true
+-enable-xfs-quota=true\
+-failed-retry-threshold=10
 ```
 
 ### Outside of Kubernetes - binary
@@ -143,14 +145,16 @@ Run nfs-provisioner with `provisioner` equal to the name you decided on, one of 
 $ sudo ./nfs-provisioner -provisioner=example.com/nfs \
 -kubeconfig=$HOME/.kube/config \
 -run-server=false \
--use-ganesha=false
+-use-ganesha=false \
+-failed-retry-threshold=10
 ```
 or
 ```
 $ sudo ./nfs-provisioner -provisioner=example.com/nfs \
 -master=http://0.0.0.0:8080 \
 -run-server=false \
--use-ganesha=false
+-use-ganesha=false \
+-failed-retry-threshold=10
 ```
 
 You may want to enable per-PV quota enforcement. It is based on xfs project level quotas and so requires that the volume mounted at `/export` be xfs mounted with the prjquota/pquota option. Add the `-enable-xfs-quota=true` argument to enable it.
@@ -160,7 +164,8 @@ $ sudo ./nfs-provisioner -provisioner=example.com/nfs \
 -kubeconfig=$HOME/.kube/config \
 -run-server=false \
 -use-ganesha=false \
--enable-xfs-quota=true
+-enable-xfs-quota=true \
+-failed-retry-threshold=10
 ```
 
 ---
@@ -179,3 +184,4 @@ The pod requires authorization to `list` all `StorageClasses`, `PersistentVolume
 * `grace-period` - NFS Ganesha grace period to use in seconds, from 0-180. If the server is not expected to survive restarts, i.e. it is running as a pod & its export directory is not persisted, this can be set to 0. Can only be set if both run-server and use-ganesha are true. Default 90.
 * `root-squash` - If the provisioner will squash root users by adding the NFS Ganesha root_id_squash or kernel root_squash option to each export. Default false.
 * `enable-xfs-quota` - If the provisioner will set xfs quotas for each volume it provisions. Requires that the directory it creates volumes in ('/export') is xfs mounted with option prjquota/pquota, and that it has the privilege to run xfs_quota. Default false.
+* `failed-retry-threshold` - If the number of retries on provisioning failure need to be limited to a set number of attempts. Default 10 

--- a/main.go
+++ b/main.go
@@ -42,7 +42,7 @@ var (
 	gracePeriod          = flag.Uint("grace-period", 90, "NFS Ganesha grace period to use in seconds, from 0-180. If the server is not expected to survive restarts, i.e. it is running as a pod & its export directory is not persisted, this can be set to 0. Can only be set if both run-server and use-ganesha are true. Default 90.")
 	rootSquash           = flag.Bool("root-squash", false, "If the provisioner will squash root users by adding the NFS Ganesha root_id_squash or kernel root_squash option to each export. Default false.")
 	enableXfsQuota       = flag.Bool("enable-xfs-quota", false, "If the provisioner will set xfs quotas for each volume it provisions. Requires that the directory it creates volumes in ('/export') is xfs mounted with option prjquota/pquota, and that it has the privilege to run xfs_quota. Default false.")
-	failedRetryThreshold = flag.Int("retries", 3, "number of retries on failure of provisioner. Default 3")
+	failedRetryThreshold = flag.Int("failed-retry-threshold", 10, "If the number of retries on provisioning failure need to be limited to a set number of attempts. Default 10")
 )
 
 const exportDir = "/export"

--- a/main.go
+++ b/main.go
@@ -34,14 +34,15 @@ import (
 )
 
 var (
-	provisioner    = flag.String("provisioner", "example.com/nfs", "Name of the provisioner. The provisioner will only provision volumes for claims that request a StorageClass with a provisioner field set equal to this name.")
-	master         = flag.String("master", "", "Master URL to build a client config from. Either this or kubeconfig needs to be set if the provisioner is being run out of cluster.")
-	kubeconfig     = flag.String("kubeconfig", "", "Absolute path to the kubeconfig file. Either this or master needs to be set if the provisioner is being run out of cluster.")
-	runServer      = flag.Bool("run-server", true, "If the provisioner is responsible for running the NFS server, i.e. starting and stopping NFS Ganesha. Default true.")
-	useGanesha     = flag.Bool("use-ganesha", true, "If the provisioner will create volumes using NFS Ganesha (D-Bus method calls) as opposed to using the kernel NFS server ('exportfs'). If run-server is true, this must be true. Default true.")
-	gracePeriod    = flag.Uint("grace-period", 90, "NFS Ganesha grace period to use in seconds, from 0-180. If the server is not expected to survive restarts, i.e. it is running as a pod & its export directory is not persisted, this can be set to 0. Can only be set if both run-server and use-ganesha are true. Default 90.")
-	rootSquash     = flag.Bool("root-squash", false, "If the provisioner will squash root users by adding the NFS Ganesha root_id_squash or kernel root_squash option to each export. Default false.")
-	enableXfsQuota = flag.Bool("enable-xfs-quota", false, "If the provisioner will set xfs quotas for each volume it provisions. Requires that the directory it creates volumes in ('/export') is xfs mounted with option prjquota/pquota, and that it has the privilege to run xfs_quota. Default false.")
+	provisioner          = flag.String("provisioner", "example.com/nfs", "Name of the provisioner. The provisioner will only provision volumes for claims that request a StorageClass with a provisioner field set equal to this name.")
+	master               = flag.String("master", "", "Master URL to build a client config from. Either this or kubeconfig needs to be set if the provisioner is being run out of cluster.")
+	kubeconfig           = flag.String("kubeconfig", "", "Absolute path to the kubeconfig file. Either this or master needs to be set if the provisioner is being run out of cluster.")
+	runServer            = flag.Bool("run-server", true, "If the provisioner is responsible for running the NFS server, i.e. starting and stopping NFS Ganesha. Default true.")
+	useGanesha           = flag.Bool("use-ganesha", true, "If the provisioner will create volumes using NFS Ganesha (D-Bus method calls) as opposed to using the kernel NFS server ('exportfs'). If run-server is true, this must be true. Default true.")
+	gracePeriod          = flag.Uint("grace-period", 90, "NFS Ganesha grace period to use in seconds, from 0-180. If the server is not expected to survive restarts, i.e. it is running as a pod & its export directory is not persisted, this can be set to 0. Can only be set if both run-server and use-ganesha are true. Default 90.")
+	rootSquash           = flag.Bool("root-squash", false, "If the provisioner will squash root users by adding the NFS Ganesha root_id_squash or kernel root_squash option to each export. Default false.")
+	enableXfsQuota       = flag.Bool("enable-xfs-quota", false, "If the provisioner will set xfs quotas for each volume it provisions. Requires that the directory it creates volumes in ('/export') is xfs mounted with option prjquota/pquota, and that it has the privilege to run xfs_quota. Default false.")
+	failedRetryThreshold = flag.Int("retries", 3, "number of retries on failure of provisioner. Default 3")
 )
 
 const exportDir = "/export"
@@ -103,7 +104,7 @@ func main() {
 	nfsProvisioner := vol.NewNFSProvisioner(exportDir, clientset, outOfCluster, *useGanesha, ganeshaConfig, *rootSquash, *enableXfsQuota)
 
 	// Start the provision controller which will dynamically provision NFS PVs
-	pc := controller.NewProvisionController(clientset, 15*time.Second, *provisioner, nfsProvisioner, serverVersion.GitVersion, false)
+	pc := controller.NewProvisionController(clientset, 15*time.Second, *provisioner, nfsProvisioner, serverVersion.GitVersion, false, *failedRetryThreshold)
 	pc.Run(wait.NeverStop)
 }
 


### PR DESCRIPTION
Current code retries failed Provisioner operation indefinitely (optionally with exponential backoff). This patch enables a configurable number of retries before abandoning further attempt (helps in avoiding overloading potentially degraded backend systems) 