### PR TITLE
Externalize leader-elector config for multi-provisioner deployments

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -143,6 +143,10 @@ func NewProvisionController(
 	serverGitVersion string,
 	exponentialBackOffOnError bool,
 	failedRetryThreshold int,
+	leaseDuration time.Duration,
+	renewDeadline time.Duration,
+	retryPeriod time.Duration,
+	termLimit time.Duration,
 ) *ProvisionController {
 	identity := uuid.NewUUID()
 
@@ -171,10 +175,10 @@ func NewProvisionController(
 		createProvisionedPVRetryCount: createProvisionedPVRetryCount,
 		createProvisionedPVInterval:   createProvisionedPVInterval,
 		identity:                      identity,
-		leaseDuration:                 leaderelection.DefaultLeaseDuration,
-		renewDeadline:                 leaderelection.DefaultRenewDeadline,
-		retryPeriod:                   leaderelection.DefaultRetryPeriod,
-		termLimit:                     leaderelection.DefaultTermLimit,
+		leaseDuration:                 leaseDuration,
+		renewDeadline:                 renewDeadline,
+		retryPeriod:                   retryPeriod,
+		termLimit:                     termLimit,
 		leaderElectors:                make(map[types.UID]*leaderelection.LeaderElector),
 		mapMutex:                      &sync.Mutex{},
 		failedClaimsStats:             make(map[types.UID]int),

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kubernetes-incubator/nfs-provisioner/controller/leaderelection"
 	rl "github.com/kubernetes-incubator/nfs-provisioner/controller/leaderelection/resourcelock"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
@@ -244,7 +245,7 @@ func TestMultipleControllers(t *testing.T) {
 		ctrls := make([]*ProvisionController, test.numControllers)
 		stopChs := make([]chan struct{}, test.numControllers)
 		for i := 0; i < test.numControllers; i++ {
-			ctrls[i] = NewProvisionController(client, 15*time.Second, test.provisionerName, provisioner, "v1.5.0", false, failedRetryThreshold)
+			ctrls[i] = NewProvisionController(client, 15*time.Second, test.provisionerName, provisioner, "v1.5.0", false, failedRetryThreshold, leaderelection.DefaultLeaseDuration, leaderelection.DefaultRenewDeadline, leaderelection.DefaultRetryPeriod, leaderelection.DefaultTermLimit)
 			ctrls[i].createProvisionedPVInterval = 10 * time.Millisecond
 			ctrls[i].claimSource = claimSource
 			ctrls[i].claims.Add(newClaim("claim-1", "uid-1-1", "class-1", "", nil))
@@ -462,12 +463,8 @@ func newTestProvisionController(
 	exponentialBackOffOnError bool,
 	failedRetryThreshold int,
 ) *ProvisionController {
-	ctrl := NewProvisionController(client, resyncPeriod, provisionerName, provisioner, serverGitVersion, exponentialBackOffOnError, failedRetryThreshold)
+	ctrl := NewProvisionController(client, resyncPeriod, provisionerName, provisioner, serverGitVersion, exponentialBackOffOnError, failedRetryThreshold, 2*resyncPeriod, resyncPeriod, resyncPeriod/2, 2*resyncPeriod)
 	ctrl.createProvisionedPVInterval = 10 * time.Millisecond
-	ctrl.leaseDuration = 2 * ctrl.resyncPeriod
-	ctrl.renewDeadline = ctrl.resyncPeriod
-	ctrl.retryPeriod = ctrl.resyncPeriod / 2
-	ctrl.termLimit = 2 * ctrl.resyncPeriod
 	return ctrl
 }
 


### PR DESCRIPTION
* Facilitates tuning deployement to different cloud provisioning api SLAs
For using just the controller as a library to build other provisioners, externalizing leader election config from controller would help one in tuning leader election to suit different cloud/IaaS api response times. Default/hardcoded values of 15s do not generalize well.  