### PR TITLE
Exclude hostpath demo from test-integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ push: container
 .PHONY: push
 
 test-integration: verify-gofmt
-	go test `go list ./... | grep -v 'vendor\|e2e'`
+	go test `go list ./... | grep -v 'vendor\|e2e\|demo'`
 .PHONY: test-integration
 
 test-e2e: verify-gofmt


### PR DESCRIPTION
needs to be updated independently because of its own glide.yaml.